### PR TITLE
Move to bespoke error type

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,10 +1,10 @@
 fn main() {
     if let Err(e) = run() {
-        println!("{}", e);
+        println!("{:?}", e);
     }
 }
 
-fn run() -> std::io::Result<()> {
+fn run() -> Result<(), winmd::error::Error> {
     let reader = winmd::Reader::from_os()?;
 
     for ns in reader.namespaces() {

--- a/src/codes.rs
+++ b/src/codes.rs
@@ -17,13 +17,13 @@ pub enum TypeDefOrRef<'a> {
 }
 
 impl<'a> TypeDefOrRef<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> ParseResult<Self> {
         let code = decode(2, code);
         Ok(match code.0 {
             0 => Self::TypeDef(db.type_def().row(code.1)),
             1 => Self::TypeRef(db.type_ref().row(code.1)),
             2 => Self::TypeSpec(db.type_spec().row(code.1)),
-            _ => return Err(Error::InvalidData("Invalid TypeDefOrRef code")),
+            _ => return Err(ParseError::InvalidData("Invalid TypeDefOrRef code")),
         })
     }
 
@@ -35,7 +35,7 @@ impl<'a> TypeDefOrRef<'a> {
         }
     }
 
-    pub fn name(&'a self) -> Result<&'a str, Error> {
+    pub fn name(&'a self) -> ParseResult<&'a str> {
         match self {
             Self::TypeDef(value) => value.name(),
             Self::TypeRef(value) => value.name(),
@@ -43,7 +43,7 @@ impl<'a> TypeDefOrRef<'a> {
         }
     }
 
-    pub fn namespace(&'a self) -> Result<&'a str, Error> {
+    pub fn namespace(&'a self) -> ParseResult<&'a str> {
         match self {
             Self::TypeDef(value) => value.namespace(),
             Self::TypeRef(value) => value.namespace(),
@@ -55,7 +55,6 @@ impl<'a> TypeDefOrRef<'a> {
 impl<'a> std::fmt::Display for TypeDefOrRef<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            // TODO: how to convert ? (from std::io::Result to std::fmt::Result)
             TypeDefOrRef::TypeDef(value) => write!(f, "{}.{}", value.namespace().unwrap(), value.name().unwrap()),
             TypeDefOrRef::TypeRef(value) => write!(f, "{}.{}", value.namespace().unwrap(), value.name().unwrap()),
             TypeDefOrRef::TypeSpec(_) => write!(f, "TypeSpec"),
@@ -89,7 +88,7 @@ pub enum HasCustomAttribute<'a> {
 }
 
 impl<'a> HasCustomAttribute<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> ParseResult<Self> {
         let code = decode(5, code);
         Ok(match code.0 {
             0 => Self::MethodDef(db.method_def().row(code.1)),
@@ -114,7 +113,7 @@ impl<'a> HasCustomAttribute<'a> {
             19 => Self::GenericParam(db.generic_param().row(code.1)),
             20 => Self::GenericParamConstraint(db.generic_param_constraint().row(code.1)),
             21 => Self::MethodSpec(db.method_spec().row(code.1)),
-            _ => return Err(Error::InvalidData("Invalid HasCustomAttribute code")),
+            _ => return Err(ParseError::InvalidData("Invalid HasCustomAttribute code")),
         })
     }
 
@@ -152,12 +151,12 @@ pub enum CustomAttributeType<'a> {
 }
 
 impl<'a> CustomAttributeType<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> ParseResult<Self> {
         let code = decode(3, code);
         Ok(match code.0 {
             2 => Self::MethodDef(db.method_def().row(code.1)),
             3 => Self::MemberRef(db.member_ref().row(code.1)),
-            _ => return Err(Error::InvalidData("Invalid CustomAttributeType code")),
+            _ => return Err(ParseError::InvalidData("Invalid CustomAttributeType code")),
         })
     }
 }
@@ -171,7 +170,7 @@ pub enum MemberRefParent<'a> {
 }
 
 impl<'a> MemberRefParent<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> ParseResult<Self> {
         let code = decode(3, code);
         Ok(match code.0 {
             0 => Self::TypeDef(db.type_def().row(code.1)),
@@ -179,7 +178,7 @@ impl<'a> MemberRefParent<'a> {
             2 => Self::ModuleRef(db.module_ref().row(code.1)),
             3 => Self::MethodDef(db.method_def().row(code.1)),
             4 => Self::TypeSpec(db.type_spec().row(code.1)),
-            _ => return Err(Error::InvalidData("Invalid MemberRefParent code")),
+            _ => return Err(ParseError::InvalidData("Invalid MemberRefParent code")),
         })
     }
 }
@@ -192,13 +191,13 @@ pub enum HasConstant<'a> {
 
 impl<'a> HasConstant<'a> {
     #![allow(dead_code)]
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> ParseResult<Self> {
         let code = decode(2, code);
         Ok(match code.0 {
             0 => Self::Field(db.field().row(code.1)),
             1 => Self::Param(db.param().row(code.1)),
             2 => Self::Property(db.property().row(code.1)),
-            _ => return Err(Error::InvalidData("Invalid HasConstant code")),
+            _ => return Err(ParseError::InvalidData("Invalid HasConstant code")),
         })
     }
 

--- a/src/codes.rs
+++ b/src/codes.rs
@@ -1,7 +1,6 @@
 use crate::database::*;
 use crate::error::*;
 use crate::tables::*;
-use std::io::Result;
 
 fn decode(bits: u32, code: u32) -> (u32, u32) {
     (code & ((1 << bits) - 1), (code >> bits) - 1)
@@ -18,13 +17,13 @@ pub enum TypeDefOrRef<'a> {
 }
 
 impl<'a> TypeDefOrRef<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
         let code = decode(2, code);
         Ok(match code.0 {
             0 => Self::TypeDef(db.type_def().row(code.1)),
             1 => Self::TypeRef(db.type_ref().row(code.1)),
             2 => Self::TypeSpec(db.type_spec().row(code.1)),
-            _ => return Err(invalid_data("Invalid TypeDefOrRef code")),
+            _ => return Err(Error::InvalidData("Invalid TypeDefOrRef code")),
         })
     }
 
@@ -36,7 +35,7 @@ impl<'a> TypeDefOrRef<'a> {
         }
     }
 
-    pub fn name(&'a self) -> Result<&'a str> {
+    pub fn name(&'a self) -> Result<&'a str, Error> {
         match self {
             Self::TypeDef(value) => value.name(),
             Self::TypeRef(value) => value.name(),
@@ -44,7 +43,7 @@ impl<'a> TypeDefOrRef<'a> {
         }
     }
 
-    pub fn namespace(&'a self) -> Result<&'a str> {
+    pub fn namespace(&'a self) -> Result<&'a str, Error> {
         match self {
             Self::TypeDef(value) => value.namespace(),
             Self::TypeRef(value) => value.namespace(),
@@ -90,7 +89,7 @@ pub enum HasCustomAttribute<'a> {
 }
 
 impl<'a> HasCustomAttribute<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
         let code = decode(5, code);
         Ok(match code.0 {
             0 => Self::MethodDef(db.method_def().row(code.1)),
@@ -115,7 +114,7 @@ impl<'a> HasCustomAttribute<'a> {
             19 => Self::GenericParam(db.generic_param().row(code.1)),
             20 => Self::GenericParamConstraint(db.generic_param_constraint().row(code.1)),
             21 => Self::MethodSpec(db.method_spec().row(code.1)),
-            _ => return Err(invalid_data("Invalid HasCustomAttribute code")),
+            _ => return Err(Error::InvalidData("Invalid HasCustomAttribute code")),
         })
     }
 
@@ -153,12 +152,12 @@ pub enum CustomAttributeType<'a> {
 }
 
 impl<'a> CustomAttributeType<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
         let code = decode(3, code);
         Ok(match code.0 {
             2 => Self::MethodDef(db.method_def().row(code.1)),
             3 => Self::MemberRef(db.member_ref().row(code.1)),
-            _ => return Err(invalid_data("Invalid CustomAttributeType code")),
+            _ => return Err(Error::InvalidData("Invalid CustomAttributeType code")),
         })
     }
 }
@@ -172,7 +171,7 @@ pub enum MemberRefParent<'a> {
 }
 
 impl<'a> MemberRefParent<'a> {
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
         let code = decode(3, code);
         Ok(match code.0 {
             0 => Self::TypeDef(db.type_def().row(code.1)),
@@ -180,7 +179,7 @@ impl<'a> MemberRefParent<'a> {
             2 => Self::ModuleRef(db.module_ref().row(code.1)),
             3 => Self::MethodDef(db.method_def().row(code.1)),
             4 => Self::TypeSpec(db.type_spec().row(code.1)),
-            _ => return Err(invalid_data("Invalid MemberRefParent code")),
+            _ => return Err(Error::InvalidData("Invalid MemberRefParent code")),
         })
     }
 }
@@ -193,13 +192,13 @@ pub enum HasConstant<'a> {
 
 impl<'a> HasConstant<'a> {
     #![allow(dead_code)]
-    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self> {
+    pub(crate) fn decode(db: &'a Database, code: u32) -> Result<Self, Error> {
         let code = decode(2, code);
         Ok(match code.0 {
             0 => Self::Field(db.field().row(code.1)),
             1 => Self::Param(db.param().row(code.1)),
             2 => Self::Property(db.property().row(code.1)),
-            _ => return Err(invalid_data("Invalid HasConstant code")),
+            _ => return Err(Error::InvalidData("Invalid HasConstant code")),
         })
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -54,23 +54,23 @@ pub(crate) struct RowData<'a> {
 }
 
 impl<'a> RowData<'a> {
-    pub fn str(&self, column: u32) -> Result<&str, Error> {
+    pub fn str(&self, column: u32) -> ParseResult<&str> {
         self.table.str(self.index, column)
     }
 
-    pub fn blob(&self, column: u32) -> Result<&[u8], Error> {
+    pub fn blob(&self, column: u32) -> ParseResult<&[u8]> {
         self.table.blob(self.index, column)
     }
 
-    pub fn blob_as<T>(&self, column: u32) -> Result<&T, Error> {
+    pub fn blob_as<T>(&self, column: u32) -> ParseResult<&T> {
         self.blob(column)?.view_as::<T>(0)
     }
 
-    pub fn u32(&self, column: u32) -> Result<u32, Error> {
+    pub fn u32(&self, column: u32) -> ParseResult<u32> {
         self.table.u32(self.index, column)
     }
 
-    pub fn list<T: Row<'a>>(&self, column: u32, table: &Table<'a>) -> Result<RowIterator<'a, T>, Error> {
+    pub fn list<T: Row<'a>>(&self, column: u32, table: &Table<'a>) -> ParseResult<RowIterator<'a, T>> {
         let first = self.u32(column)? - 1;
         let last = if self.index + 1 < self.table.len() { self.table.u32(self.index + 1, column)? - 1 } else { table.len() };
         Ok(RowIterator::new(table, first, last))
@@ -101,18 +101,18 @@ impl<'a> Table<'a> {
         self.data.row_count
     }
 
-    pub fn str(&self, row: u32, column: u32) -> Result<&str, Error> {
+    pub fn str(&self, row: u32, column: u32) -> ParseResult<&str> {
         let offset = (self.db.strings + self.u32(row, column)?) as usize;
         match self.db.bytes[offset..].iter().position(|c| *c == b'\0') {
             None => Err(unexpected_eof()),
             Some(last) => match std::str::from_utf8(&self.db.bytes[offset..offset + last]) {
                 Ok(string) => Ok(string),
-                Err(_) => Err(Error::InvalidData("Bytes not valid UTF-8")),
+                Err(_) => Err(ParseError::InvalidData("Bytes not valid UTF-8")),
             },
         }
     }
 
-    pub fn blob(&self, row: u32, column: u32) -> Result<&[u8], Error> {
+    pub fn blob(&self, row: u32, column: u32) -> ParseResult<&[u8]> {
         let offset = (self.db.blobs + self.u32(row, column)?) as usize;
         let mut initial_byte = self.db.bytes[offset];
         let blob_size_bytes;
@@ -129,7 +129,7 @@ impl<'a> Table<'a> {
                 blob_size_bytes = 4;
                 initial_byte &= 0x1f;
             }
-            _ => return Err(Error::InvalidData("Invalid blob encoding")),
+            _ => return Err(ParseError::InvalidData("Invalid blob encoding")),
         };
         let mut blob_size = initial_byte;
         for byte in self.db.bytes[offset + 1..offset + blob_size_bytes].iter() {
@@ -138,7 +138,7 @@ impl<'a> Table<'a> {
         Ok(&self.db.bytes[offset + blob_size_bytes..offset + blob_size_bytes + blob_size as usize])
     }
 
-    pub fn u32(&self, row: u32, column: u32) -> Result<u32, Error> {
+    pub fn u32(&self, row: u32, column: u32) -> ParseResult<u32> {
         let offset = self.data.data + row * self.data.row_size + self.data.columns[column as usize].0;
         match self.data.columns[column as usize].1 {
             1 => Ok(*(self.db.bytes.view_as::<u8>(offset)?) as u32),
@@ -148,7 +148,7 @@ impl<'a> Table<'a> {
         }
     }
 
-    fn lower_bound_of(&self, mut first: u32, last: u32, column: u32, value: u32) -> Result<u32, Error> {
+    fn lower_bound_of(&self, mut first: u32, last: u32, column: u32, value: u32) -> ParseResult<u32> {
         let mut count = last - first;
         while count > 0 {
             let count2 = count / 2;
@@ -163,15 +163,15 @@ impl<'a> Table<'a> {
         Ok(first)
     }
 
-    pub fn upper_bound<T: Row<'a>>(&self, column: u32, value: u32) -> Result<T, Error> {
+    pub fn upper_bound<T: Row<'a>>(&self, column: u32, value: u32) -> ParseResult<T> {
         let index = self.upper_bound_of(0, self.data.row_count, column, value)?;
         if index == self.data.row_count {
-            return Err(Error::InvalidData("Invalid row index"));
+            return Err(ParseError::InvalidData("Invalid row index"));
         }
         Ok(T::new(self, index))
     }
 
-    fn upper_bound_of(&self, mut first: u32, last: u32, column: u32, value: u32) -> Result<u32, Error> {
+    fn upper_bound_of(&self, mut first: u32, last: u32, column: u32, value: u32) -> ParseResult<u32> {
         let mut count = last - first;
         while count > 0 {
             let count2 = count / 2;
@@ -186,11 +186,11 @@ impl<'a> Table<'a> {
         Ok(first)
     }
 
-    pub fn equal_range<T: Row<'a>>(&self, column: u32, value: u32) -> Result<RowIterator<'a, T>, Error> {
+    pub fn equal_range<T: Row<'a>>(&self, column: u32, value: u32) -> ParseResult<RowIterator<'a, T>> {
         Ok(T::from_rows(self, self.equal_range_of(0, self.data.row_count, column, value)?))
     }
 
-    fn equal_range_of(&self, mut first: u32, mut last: u32, column: u32, value: u32) -> Result<(u32, u32), Error> {
+    fn equal_range_of(&self, mut first: u32, mut last: u32, column: u32, value: u32) -> ParseResult<(u32, u32)> {
         let mut count = last - first;
         loop {
             if count <= 0 {
@@ -315,25 +315,25 @@ pub struct Database {
 }
 
 impl Database {
-    pub fn new<P: AsRef<std::path::Path>>(filename: P) -> Result<Self, Error> {
+    pub fn new<P: AsRef<std::path::Path>>(filename: P) -> ParseResult<Self> {
         let mut db = Self { bytes: std::fs::read(filename)?, ..Default::default() };
         let dos = db.bytes.view_as::<ImageDosHeader>(0)?;
         if dos.signature != IMAGE_DOS_SIGNATURE {
-            return Err(Error::InvalidData("Invalid DOS signature"));
+            return Err(ParseError::InvalidData("Invalid DOS signature"));
         }
         let pe = db.bytes.view_as::<ImageNtHeader>(dos.lfanew as u32)?;
         let (com_virtual_address, sections) = match pe.optional_header.magic {
             MAGIC_PE32 => (pe.optional_header.data_directory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR as usize].virtual_address, db.bytes.view_as_slice_of::<ImageSectionHeader>(dos.lfanew as u32 + sizeof::<ImageNtHeader>(), pe.file_header.number_of_sections as u32)?),
             MAGIC_PE32PLUS => (db.bytes.view_as::<ImageNtHeaderPlus>(dos.lfanew as u32)?.optional_header.data_directory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR as usize].virtual_address, db.bytes.view_as_slice_of::<ImageSectionHeader>(dos.lfanew as u32 + sizeof::<ImageNtHeaderPlus>(), pe.file_header.number_of_sections as u32)?),
-            _ => return Err(Error::InvalidData("Invalid optional header magic value")),
+            _ => return Err(ParseError::InvalidData("Invalid optional header magic value")),
         };
         let cli = db.bytes.view_as::<ImageCorHeader>(offset_from_rva(section_from_rva(sections, com_virtual_address)?, com_virtual_address))?;
         if cli.cb != sizeof::<ImageCorHeader>() {
-            return Err(Error::InvalidData("Invalid CLI header"));
+            return Err(ParseError::InvalidData("Invalid CLI header"));
         }
         let cli_offset = offset_from_rva(section_from_rva(sections, cli.meta_data.virtual_address)?, cli.meta_data.virtual_address);
         if *db.bytes.view_as::<u32>(cli_offset)? != STORAGE_MAGIC_SIG {
-            return Err(Error::InvalidData("CLI metadata magic signature not found"));
+            return Err(ParseError::InvalidData("CLI metadata magic signature not found"));
         }
         let version_length = *db.bytes.view_as::<u32>(cli_offset + 12)?;
         let mut view = cli_offset + version_length + 20;
@@ -348,7 +348,7 @@ impl Database {
                 b"#GUID" => db.guids = cli_offset + stream_offset,
                 b"#~" => tables_data = (cli_offset + stream_offset, stream_size),
                 b"#US" => {}
-                _ => return Err(Error::InvalidData("Unknown metadata stream")),
+                _ => return Err(ParseError::InvalidData("Unknown metadata stream")),
             }
             let mut padding = 4 - stream_name.len() % 4;
             if padding == 0 {
@@ -407,7 +407,7 @@ impl Database {
                 0x2a => db.generic_param.row_count = row_count,
                 0x2b => db.method_spec.row_count = row_count,
                 0x2c => db.generic_param_constraint.row_count = row_count,
-                _ => return Err(Error::InvalidData("Unknown metadata table")),
+                _ => return Err(ParseError::InvalidData("Unknown metadata table")),
             };
         }
         let empty_table = TableData::default();
@@ -546,8 +546,8 @@ impl Database {
     table_fn!(type_spec);
 }
 
-fn section_from_rva(sections: &[ImageSectionHeader], rva: u32) -> Result<&ImageSectionHeader, Error> {
-    sections.iter().find(|&s| rva >= s.virtual_address && rva < s.virtual_address + s.physical_address_or_virtual_size).ok_or_else(|| Error::InvalidData("Section containing RVA not found"))
+fn section_from_rva(sections: &[ImageSectionHeader], rva: u32) -> ParseResult<&ImageSectionHeader> {
+    sections.iter().find(|&s| rva >= s.virtual_address && rva < s.virtual_address + s.physical_address_or_virtual_size).ok_or_else(|| ParseError::InvalidData("Section containing RVA not found"))
 }
 
 fn offset_from_rva(section: &ImageSectionHeader, rva: u32) -> u32 {
@@ -583,28 +583,28 @@ fn composite_index_size(tables: &[&TableData]) -> u32 {
 }
 
 trait View {
-    fn view_as<T>(&self, cli_offset: u32) -> Result<&T, Error>;
-    fn view_as_slice_of<T>(&self, cli_offset: u32, len: u32) -> Result<&[T], Error>;
-    fn view_as_str(&self, cli_offset: u32) -> Result<&[u8], Error>;
+    fn view_as<T>(&self, cli_offset: u32) -> ParseResult<&T>;
+    fn view_as_slice_of<T>(&self, cli_offset: u32, len: u32) -> ParseResult<&[T]>;
+    fn view_as_str(&self, cli_offset: u32) -> ParseResult<&[u8]>;
 }
 
 // TODO: remove use of unsafe blocks by simply indexing into the struct/fields with offsets
 // and avoiding the structs altogether.
 
 impl View for [u8] {
-    fn view_as<T>(&self, cli_offset: u32) -> Result<&T, Error> {
+    fn view_as<T>(&self, cli_offset: u32) -> ParseResult<&T> {
         if cli_offset + sizeof::<T>() > self.len() as u32 {
             return Err(unexpected_eof());
         }
         unsafe { Ok(&*(&self[cli_offset as usize] as *const u8 as *const T)) }
     }
-    fn view_as_slice_of<T>(&self, cli_offset: u32, len: u32) -> Result<&[T], Error> {
+    fn view_as_slice_of<T>(&self, cli_offset: u32, len: u32) -> ParseResult<&[T]> {
         if cli_offset + sizeof::<T>() * len > self.len() as u32 {
             return Err(unexpected_eof());
         }
         unsafe { Ok(std::slice::from_raw_parts(&self[cli_offset as usize] as *const u8 as *const T, len as usize)) }
     }
-    fn view_as_str(&self, cli_offset: u32) -> Result<&[u8], Error> {
+    fn view_as_str(&self, cli_offset: u32) -> ParseResult<&[u8]> {
         match self.get(cli_offset as usize..).ok_or_else(|| unexpected_eof())?.iter().position(|c| *c == b'\0') {
             Some(index) => Ok(&self[cli_offset as usize..cli_offset as usize + index]),
             None => Err(unexpected_eof()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,19 +3,39 @@ use std::io;
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
-    InvalidData(&'static str),
-}
-
-pub fn unexpected_eof() -> Error {
-    Error::Io(io::Error::from(io::ErrorKind::UnexpectedEof))
-}
-
-pub fn unsupported_blob() -> Error {
-    Error::InvalidData("Unsupported blob")
+    ParseError(ParseError),
 }
 
 impl std::convert::From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Error::Io(error)
+    }
+}
+
+impl std::convert::From<ParseError> for Error {
+    fn from(error: ParseError) -> Self {
+        Error::ParseError(error)
+    }
+}
+
+pub type ParseResult<T> = Result<T, ParseError>;
+
+#[derive(Debug)]
+pub enum ParseError {
+    Io(io::Error),
+    InvalidData(&'static str),
+}
+
+pub fn unexpected_eof() -> ParseError {
+    ParseError::Io(io::Error::from(io::ErrorKind::UnexpectedEof))
+}
+
+pub fn unsupported_blob() -> ParseError {
+    ParseError::InvalidData("Unsupported blob")
+}
+
+impl std::convert::From<io::Error> for ParseError {
+    fn from(error: io::Error) -> Self {
+        ParseError::Io(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,21 @@
-// TODO: add winmd::Result and winmd::Error
+use std::io;
 
-pub fn invalid_data(message: &str) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::InvalidData, message)
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    InvalidData(&'static str),
+}
+
+pub fn unexpected_eof() -> Error {
+    Error::Io(io::Error::from(io::ErrorKind::UnexpectedEof))
+}
+
+pub fn unsupported_blob() -> Error {
+    Error::InvalidData("Unsupported blob")
+}
+
+impl std::convert::From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod codes;
 mod database;
-mod error;
+pub mod error;
 mod flags;
 mod reader;
 mod signatures;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -116,10 +116,7 @@ impl<'a> Reader {
 
     pub fn from_os() -> Result<Self, Error> {
         let mut path = std::path::PathBuf::new();
-        path.push(match std::env::var("windir") {
-            Ok(value) => value,
-            Err(_) => return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "'windir' environment variable not found").into()),
-        });
+        path.push(std::env::var("windir").expect("'windir' environment variable not found"));
         path.push(SYSTEM32);
         path.push("winmetadata");
         Self::from_dir(path)

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -3,8 +3,8 @@
 
 use crate::codes::*;
 use crate::database::*;
+use crate::error::*;
 use crate::tables::*;
-use std::io::Result;
 use std::vec::*;
 
 // TODO: what about using std::io::Read?
@@ -15,7 +15,7 @@ pub struct GenericSig<'a> {
 }
 
 impl<'a> GenericSig<'a> {
-    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<GenericSig<'a>> {
+    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<GenericSig<'a>, Error> {
         let (_, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
 
@@ -55,7 +55,7 @@ pub struct ModifierSig<'a> {
 }
 
 impl<'a> ModifierSig<'a> {
-    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<ModifierSig<'a>> {
+    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<ModifierSig<'a>, Error> {
         let (_, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
         let (code, bytes_read) = read_u32(bytes)?;
@@ -64,7 +64,7 @@ impl<'a> ModifierSig<'a> {
         Ok(ModifierSig { type_code })
     }
 
-    fn vec(db: &'a Database, bytes: &mut &[u8]) -> Result<Vec<ModifierSig<'a>>> {
+    fn vec(db: &'a Database, bytes: &mut &[u8]) -> Result<Vec<ModifierSig<'a>>, Error> {
         let mut modifiers = Vec::new();
         loop {
             let (element_type, _) = read_u32(bytes)?;
@@ -84,7 +84,7 @@ pub struct MethodSig<'a> {
 }
 
 impl<'a> MethodSig<'a> {
-    pub(crate) fn new(method: &MethodDef<'a>) -> Result<MethodSig<'a>> {
+    pub(crate) fn new(method: &MethodDef<'a>) -> Result<MethodSig<'a>, Error> {
         let mut bytes = method.row.blob(4)?;
         let (calling_convention, bytes_read) = read_u32(&mut bytes)?;
         bytes = seek(bytes, bytes_read);
@@ -122,7 +122,7 @@ pub struct ParamSig<'a> {
 }
 
 impl<'a> ParamSig<'a> {
-    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<ParamSig<'a>> {
+    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<ParamSig<'a>, Error> {
         let modifiers = ModifierSig::vec(db, bytes)?;
         let by_ref = read_expected(bytes, 0x10)?;
         let param_type = TypeSig::new(db, bytes)?;
@@ -143,7 +143,7 @@ pub enum TypeSigType<'a> {
 }
 
 impl<'a> TypeSigType<'a> {
-    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<TypeSigType<'a>> {
+    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<TypeSigType<'a>, Error> {
         let (element_type, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
 
@@ -202,7 +202,7 @@ pub struct TypeSig<'a> {
 }
 
 impl<'a> TypeSig<'a> {
-    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<TypeSig<'a>> {
+    fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<TypeSig<'a>, Error> {
         let array = read_expected(bytes, 0x1D)?;
         let modifiers = ModifierSig::vec(db, bytes)?;
         let sig_type = TypeSigType::new(db, bytes)?;
@@ -216,7 +216,7 @@ impl<'a> std::fmt::Display for TypeSig<'a> {
     }
 }
 
-fn read_expected(bytes: &mut &[u8], expected: u32) -> Result<bool> {
+fn read_expected(bytes: &mut &[u8], expected: u32) -> Result<bool, Error> {
     let (element_type, bytes_read) = read_u32(bytes)?;
     Ok(if element_type == expected {
         *bytes = seek(bytes, bytes_read);
@@ -230,7 +230,7 @@ fn seek(bytes: &[u8], bytes_read: usize) -> &[u8] {
     bytes.get(bytes_read..).unwrap()
 }
 
-fn read_u32<'a>(bytes: &[u8]) -> Result<(u32, usize)> {
+fn read_u32<'a>(bytes: &[u8]) -> Result<(u32, usize), Error> {
     if bytes.is_empty() {
         return Err(unsupported_blob());
     }
@@ -251,10 +251,6 @@ fn read_u32<'a>(bytes: &[u8]) -> Result<(u32, usize)> {
     };
 
     Ok((value, bytes_read))
-}
-
-fn unsupported_blob() -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::InvalidData, "Unsupported blob")
 }
 
 pub enum ElementType {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -75,25 +75,25 @@ impl std::fmt::Display for ConstantValue {
 }
 
 impl<'a> Constant<'a> {
-    pub fn value(&self) -> Result<ConstantValue, Error> {
+    pub fn value(&self) -> ParseResult<ConstantValue> {
         match self.row.u32(0)? {
             0x08 => Ok(ConstantValue::I32(*self.row.blob_as::<i32>(2)?)),
             0x09 => Ok(ConstantValue::U32(*self.row.blob_as::<u32>(2)?)),
-            _ => Err(Error::InvalidData("Unsupported constant type")),
+            _ => Err(ParseError::InvalidData("Unsupported constant type")),
         }
     }
 }
 
 impl<'a> CustomAttribute<'a> {
-    pub fn parent(&self) -> Result<HasCustomAttribute, Error> {
+    pub fn parent(&self) -> ParseResult<HasCustomAttribute> {
         Ok(HasCustomAttribute::decode(&self.row.table.db, self.row.u32(0)?)?)
     }
 
-    pub fn class(&self) -> Result<CustomAttributeType, Error> {
+    pub fn class(&self) -> ParseResult<CustomAttributeType> {
         Ok(CustomAttributeType::decode(&self.row.table.db, self.row.u32(1)?)?)
     }
 
-    pub fn has_name(&self, namespace: &str, name: &str) -> Result<bool, Error> {
+    pub fn has_name(&self, namespace: &str, name: &str) -> ParseResult<bool> {
         Ok(match self.class()? {
             CustomAttributeType::MethodDef(value) => {
                 let parent = value.parent()?;
@@ -109,47 +109,47 @@ impl<'a> CustomAttribute<'a> {
 }
 
 impl<'a> Field<'a> {
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(1)
     }
 
-    pub fn constants(&self) -> Result<RowIterator<'a, Constant<'a>>, Error> {
+    pub fn constants(&self) -> ParseResult<RowIterator<'a, Constant<'a>>> {
         self.row.table.db.constant().equal_range(1, HasConstant::Field(*self).encode())
     }
 }
 
 impl<'a> MemberRef<'a> {
-    pub fn class(&self) -> Result<MemberRefParent, Error> {
+    pub fn class(&self) -> ParseResult<MemberRefParent> {
         Ok(MemberRefParent::decode(&self.row.table.db, self.row.u32(0)?)?)
     }
 
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(1)
     }
 }
 
 impl<'a> MethodDef<'a> {
-    pub fn flags(&self) -> Result<MethodAttributes, Error> {
+    pub fn flags(&self) -> ParseResult<MethodAttributes> {
         Ok(MethodAttributes(self.row.u32(2)?))
     }
 
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(3)
     }
 
-    pub(crate) fn params(&self) -> Result<RowIterator<'a, Param<'a>>, Error> {
+    pub(crate) fn params(&self) -> ParseResult<RowIterator<'a, Param<'a>>> {
         self.row.list(5, &self.row.table.db.param())
     }
 
-    pub fn parent(&self) -> Result<TypeDef, Error> {
+    pub fn parent(&self) -> ParseResult<TypeDef> {
         self.row.table.db.type_def().upper_bound(6, self.row.index)
     }
 
-    pub fn signature(&self) -> Result<MethodSig, Error> {
+    pub fn signature(&self) -> ParseResult<MethodSig> {
         MethodSig::new(self)
     }
 
-    pub fn rust_name(&self) -> Result<String, Error> {
+    pub fn rust_name(&self) -> ParseResult<String> {
         let mut source = self.name()?;
         let mut result = String::with_capacity(source.len() + 2);
 
@@ -190,45 +190,45 @@ impl<'a> MethodDef<'a> {
 }
 
 impl<'a> Param<'a> {
-    pub fn sequence(&self) -> Result<u32, Error> {
+    pub fn sequence(&self) -> ParseResult<u32> {
         self.row.u32(1)
     }
 
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(2)
     }
 }
 
 impl<'a> TypeDef<'a> {
-    pub fn flags(&self) -> Result<TypeAttributes, Error> {
+    pub fn flags(&self) -> ParseResult<TypeAttributes> {
         Ok(TypeAttributes(self.row.u32(0)?))
     }
 
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(1)
     }
 
-    pub fn namespace(&self) -> Result<&str, Error> {
+    pub fn namespace(&self) -> ParseResult<&str> {
         self.row.str(2)
     }
 
-    pub fn extends(&self) -> Result<TypeDefOrRef, Error> {
+    pub fn extends(&self) -> ParseResult<TypeDefOrRef> {
         Ok(TypeDefOrRef::decode(&self.row.table.db, self.row.u32(3)?)?)
     }
 
-    pub fn fields(&self) -> Result<RowIterator<'a, Field<'a>>, Error> {
+    pub fn fields(&self) -> ParseResult<RowIterator<'a, Field<'a>>> {
         self.row.list(4, &self.row.table.db.field())
     }
 
-    pub fn methods(&self) -> Result<RowIterator<'a, MethodDef<'a>>, Error> {
+    pub fn methods(&self) -> ParseResult<RowIterator<'a, MethodDef<'a>>> {
         self.row.list(5, &self.row.table.db.method_def())
     }
 
-    pub fn attributes(&self) -> Result<RowIterator<'a, CustomAttribute<'a>>, Error> {
+    pub fn attributes(&self) -> ParseResult<RowIterator<'a, CustomAttribute<'a>>> {
         self.row.table.db.custom_attribute().equal_range(0, HasCustomAttribute::TypeDef(*self).encode())
     }
 
-    pub fn has_attribute(&self, namespace: &str, name: &str) -> Result<bool, Error> {
+    pub fn has_attribute(&self, namespace: &str, name: &str) -> ParseResult<bool> {
         for attribute in self.attributes()? {
             if attribute.has_name(namespace, name)? {
                 return Ok(true);
@@ -239,11 +239,11 @@ impl<'a> TypeDef<'a> {
 }
 
 impl<'a> TypeRef<'a> {
-    pub fn name(&self) -> Result<&str, Error> {
+    pub fn name(&self) -> ParseResult<&str> {
         self.row.str(1)
     }
 
-    pub fn namespace(&self) -> Result<&str, Error> {
+    pub fn namespace(&self) -> ParseResult<&str> {
         self.row.str(2)
     }
 }


### PR DESCRIPTION
This is the bare minimum for moving to a custom error type instead of relying on std::io::Error. 

Most of the errors seem to be parsing errors, but in reader.rs the errors in `from_os` and `from_dir` are not parsing related. For example, there is an error that has to do with an expected env variable not being on the user's system. We probably want to have a separate error type for that. 

For parsing errors we may want to have `error::ParseError` and have `type ParseResult<T> = Result<T, error::ParseError>. We can then consider if we have an `WinmdError` type that can be among other things a `ParseError` or if we want to keep the error types completely disjoint. 

Also, there's many types of invalid data. How specific do we want to be? 

Fixes #6 
