### PR TITLE
Test-ability improvements

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -4,7 +4,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), winmd::error::Error> {
+fn run() -> Result<(), winmd::Error> {
     let reader = winmd::Reader::from_os()?;
 
     for ns in reader.namespaces() {

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -22,10 +22,10 @@ fn run() -> std::io::Result<()> {
 
                 if let Some((last, rest)) = sig.params().split_last() {
                     for (param, signature) in rest {
-                        print!("{}: {}, ", param.name()?, signature.param_type());
+                        print!("{}: {}, ", param.name()?, signature.sig_type());
                     }
                     let (param, signature) = last;
-                    print!("{}: {}", param.name()?, signature.param_type());
+                    print!("{}: {}", param.name()?, signature.sig_type());
                 }
 
                 match sig.return_type() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,11 +26,11 @@ pub enum ParseError {
     InvalidData(&'static str),
 }
 
-pub fn unexpected_eof() -> ParseError {
+pub(crate) fn unexpected_eof() -> ParseError {
     ParseError::Io(io::Error::from(io::ErrorKind::UnexpectedEof))
 }
 
-pub fn unsupported_blob() -> ParseError {
+pub(crate) fn unsupported_blob() -> ParseError {
     ParseError::InvalidData("Unsupported blob")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 mod codes;
 mod database;
-pub mod error;
+mod error;
 mod flags;
 mod reader;
 mod signatures;
 mod tables;
 
 pub use codes::*;
+pub use error::*;
 pub use reader::*;
+pub use signatures::*;
 pub use tables::*;

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -7,8 +7,6 @@ use crate::error::*;
 use crate::tables::*;
 use std::vec::*;
 
-// TODO: what about using std::io::Read?
-
 pub struct GenericSig<'a> {
     sig_type: TypeDefOrRef<'a>,
     args: Vec<TypeSig<'a>>,

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -10,7 +10,7 @@ use std::vec::*;
 // TODO: what about using std::io::Read?
 
 pub struct GenericSig<'a> {
-    generic_type: TypeDefOrRef<'a>,
+    sig_type: TypeDefOrRef<'a>,
     args: Vec<TypeSig<'a>>,
 }
 
@@ -21,7 +21,7 @@ impl<'a> GenericSig<'a> {
 
         let (code, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
-        let generic_type = TypeDefOrRef::decode(db, code)?;
+        let sig_type = TypeDefOrRef::decode(db, code)?;
 
         let (arg_count, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
@@ -32,11 +32,11 @@ impl<'a> GenericSig<'a> {
             args.push(TypeSig::new(db, bytes)?);
         }
 
-        Ok(GenericSig { generic_type, args })
+        Ok(GenericSig { sig_type, args })
     }
 
-    pub fn generic_type(&self) -> &TypeDefOrRef<'a> {
-        &self.generic_type
+    pub fn sig_type(&self) -> &TypeDefOrRef<'a> {
+        &self.sig_type
     }
 
     pub fn args(&self) -> &Vec<TypeSig<'a>> {
@@ -46,12 +46,12 @@ impl<'a> GenericSig<'a> {
 
 impl<'a> std::fmt::Display for GenericSig<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.generic_type)
+        write!(f, "{}", self.sig_type)
     }
 }
 
 pub struct ModifierSig<'a> {
-    type_code: TypeDefOrRef<'a>,
+    sig_type: TypeDefOrRef<'a>,
 }
 
 impl<'a> ModifierSig<'a> {
@@ -60,8 +60,8 @@ impl<'a> ModifierSig<'a> {
         *bytes = seek(bytes, bytes_read);
         let (code, bytes_read) = read_u32(bytes)?;
         *bytes = seek(bytes, bytes_read);
-        let type_code = TypeDefOrRef::decode(db, code)?;
-        Ok(ModifierSig { type_code })
+        let sig_type = TypeDefOrRef::decode(db, code)?;
+        Ok(ModifierSig { sig_type })
     }
 
     fn vec(db: &'a Database, bytes: &mut &[u8]) -> Result<Vec<ModifierSig<'a>>> {
@@ -118,19 +118,19 @@ impl<'a> MethodSig<'a> {
 pub struct ParamSig<'a> {
     modifiers: Vec<ModifierSig<'a>>,
     by_ref: bool,
-    param_type: TypeSig<'a>,
+    sig_type: TypeSig<'a>,
 }
 
 impl<'a> ParamSig<'a> {
     fn new(db: &'a Database, bytes: &mut &[u8]) -> Result<ParamSig<'a>> {
         let modifiers = ModifierSig::vec(db, bytes)?;
         let by_ref = read_expected(bytes, 0x10)?;
-        let param_type = TypeSig::new(db, bytes)?;
-        Ok(ParamSig { modifiers, by_ref, param_type })
+        let sig_type = TypeSig::new(db, bytes)?;
+        Ok(ParamSig { modifiers, by_ref, sig_type })
     }
 
-    pub fn param_type(&self) -> &TypeSig<'a> {
-        &self.param_type
+    pub fn sig_type(&self) -> &TypeSig<'a> {
+        &self.sig_type
     }
 }
 
@@ -207,6 +207,10 @@ impl<'a> TypeSig<'a> {
         let modifiers = ModifierSig::vec(db, bytes)?;
         let sig_type = TypeSigType::new(db, bytes)?;
         Ok(TypeSig { array, modifiers, sig_type })
+    }
+
+    pub fn sig_type(&self) -> &TypeSigType<'a> {
+        &self.sig_type
     }
 }
 

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -257,6 +257,7 @@ fn read_u32<'a>(bytes: &[u8]) -> ParseResult<(u32, usize)> {
     Ok((value, bytes_read))
 }
 
+#[derive(PartialEq)]
 pub enum ElementType {
     Bool,
     Char,

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -1,36 +1,47 @@
 #[test]
-fn type_def() {
-    let reader = winmd::Reader::from_os().unwrap();
+fn type_def() -> Result<(), winmd::Error> {
+    let reader = winmd::Reader::from_os()?;
     let t: winmd::TypeDef = reader.find("Windows.Foundation", "IStringable").unwrap();
 
-    let flags = t.flags().unwrap();
+    let flags = t.flags()?;
     assert!(flags.windows_runtime());
     assert!(flags.interface());
 
-    assert!(t.name().unwrap() == "IStringable");
-    assert!(t.namespace().unwrap() == "Windows.Foundation");
-    assert!(t.methods().unwrap().count() == 1);
+    assert!(t.name()? == "IStringable");
+    assert!(t.namespace()? == "Windows.Foundation");
+    assert!(t.methods()?.count() == 1);
 
-    for m in t.methods().unwrap() {
-        assert!(m.name().unwrap() == "ToString");
-        let sig = m.signature().unwrap();
-        let return_type = sig.return_type();
+    for m in t.methods()? {
+        assert!(m.name()? == "ToString");
+        let sig = m.signature()?;
+        assert!(sig.return_type().is_some());
 
+        if let Some(return_type) = sig.return_type() {
+            if let winmd::TypeSigType::ElementType(value) = return_type.sig_type() {
+                assert!(*value == winmd::ElementType::String);
+            } else {
+                assert!(false);
+            }
+        } else {
+            assert!(false);
+        }
     }
 
-    assert!(t.has_attribute("Windows.Foundation.Metadata", "GuidAttribute").unwrap());
+    assert!(t.has_attribute("Windows.Foundation.Metadata", "GuidAttribute")?);
+    Ok(())
 }
 
 #[test]
-fn type_ref() {
-    let reader = winmd::Reader::from_os().unwrap();
+fn type_ref() -> Result<(), winmd::Error> {
+    let reader = winmd::Reader::from_os()?;
     let t = reader.find("Windows.Foundation", "AsyncStatus").unwrap();
 
-    if let winmd::TypeDefOrRef::TypeRef(value) = t.extends().unwrap() {
+    if let winmd::TypeDefOrRef::TypeRef(value) = t.extends()? {
         let t: winmd::TypeRef = value;
-        assert!(t.name().unwrap() == "Enum");
-        assert!(t.namespace().unwrap() == "System");
+        assert!(t.name()? == "Enum");
+        assert!(t.namespace()? == "System");
     } else {
         assert!(false);
     }
+    Ok(())
 }

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -13,6 +13,9 @@ fn type_def() {
 
     for m in t.methods().unwrap() {
         assert!(m.name().unwrap() == "ToString");
+        let sig = m.signature().unwrap();
+        let return_type = sig.return_type();
+
     }
 
     assert!(t.has_attribute("Windows.Foundation.Metadata", "GuidAttribute").unwrap());


### PR DESCRIPTION
* Use a consistent name for signature types. Regrettably "type" is a keyword in Rust... 😉 
* Flatten the crate's public types. No need for public sub modules at this stage.
* Avoid making internal error functions public.
* Simplify tests by using Result return type.
* More concise signature parsing.