### PR TITLE
Add trait implementations for structs

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -53,6 +53,7 @@ pub fn type_code(args: TokenStream, input: TokenStream) -> TokenStream {
     let encodes = TokenStream2::from_iter(encodes);
 
     let output = quote!(
+        #[derive(Debug, Clone, PartialEq, Eq)]
         pub enum #name<'a> {
             #variants
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{error, fmt, io};
 
 #[derive(Debug)]
 pub enum ParseError {
@@ -10,11 +10,37 @@ pub enum ParseError {
     InvalidBlob,
 }
 
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => fmt::Display::fmt(err, f),
+            Self::MissingType(ty) => write!(f, "Missing type: {}", ty),
+            Self::MissingAttribute => write!(f, "Missing attribute"),
+            Self::InvalidFile => write!(f, "Invalid file"),
+            Self::InvalidTypeName => write!(f, "Invalid type name"),
+            Self::InvalidBlob => write!(f, "Invalid blob"),
+        }
+    }
+}
+
+impl error::Error for ParseError {}
+
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
     ParseError(ParseError),
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => fmt::Display::fmt(err, f),
+            Self::ParseError(err) => fmt::Display::fmt(err, f),
+        }
+    }
+}
+
+impl error::Error for Error {}
 
 pub type ParseResult<T> = Result<T, ParseError>;
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,3 @@
-#![allow(exceeding_bitshifts)]
-
 use crate::error::*;
 use crate::reader::*;
 use std::marker::PhantomData;
@@ -12,7 +10,7 @@ macro_rules! table_fn {
     };
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, Eq, Default)]
 pub struct File {
     bytes: Vec<u8>,
     strings: u32,
@@ -32,7 +30,7 @@ pub struct File {
     pub type_spec: TableData,
 }
 
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct TableData {
     data: u32,
     row_count: u32,
@@ -40,19 +38,20 @@ pub struct TableData {
     columns: [(u32, u32); 6],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Table<'a> {
     pub(crate) file: &'a File,
     pub(crate) reader: &'a Reader,
     data: &'a TableData,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct RowData<'a> {
     pub(crate) table: Table<'a>,
     pub(crate) index: u32,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RowIterator<'a, T: Row<'a>> {
     table: Table<'a>,
     first: u32,
@@ -527,7 +526,7 @@ fn section_from_rva(sections: &[ImageSectionHeader], rva: u32) -> ParseResult<&I
 }
 
 fn offset_from_rva(section: &ImageSectionHeader, rva: u32) -> u32 {
-    (rva - section.virtual_address + section.pointer_to_raw_data)
+    rva - section.virtual_address + section.pointer_to_raw_data
 }
 
 fn sizeof<T>() -> u32 {
@@ -599,6 +598,7 @@ const IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR: u32 = 14;
 const STORAGE_MAGIC_SIG: u32 = 0x424A5342;
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageDosHeader {
     signature: u16,
     cblp: u16,
@@ -622,6 +622,7 @@ struct ImageDosHeader {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageFileHeader {
     machine: u16,
     number_of_sections: u16,
@@ -633,12 +634,14 @@ struct ImageFileHeader {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageDataDirectory {
     virtual_address: u32,
     size: u32,
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageOptionalHeader {
     magic: u16,
     major_linker_version: u8,
@@ -674,6 +677,7 @@ struct ImageOptionalHeader {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageNtHeader {
     signature: u32,
     file_header: ImageFileHeader,
@@ -681,6 +685,7 @@ struct ImageNtHeader {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageOptionalHeaderPlus {
     magic: u16,
     major_linker_version: u8,
@@ -715,6 +720,7 @@ struct ImageOptionalHeaderPlus {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageNtHeaderPlus {
     signature: u32,
     file_header: ImageFileHeader,
@@ -722,6 +728,7 @@ struct ImageNtHeaderPlus {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageSectionHeader {
     name: [u8; 8],
     physical_address_or_virtual_size: u32,
@@ -736,6 +743,7 @@ struct ImageSectionHeader {
 }
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ImageCorHeader {
     cb: u32,
     major_runtime_version: u16,

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,3 +1,5 @@
+#![allow(arithmetic_overflow)]
+
 use crate::error::*;
 use crate::reader::*;
 use std::marker::PhantomData;

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,4 +1,9 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct MethodAttributes(pub(crate) u32);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct TypeAttributes(pub(crate) u32);
 
 impl MethodAttributes {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,28 +3,32 @@ use crate::file::*;
 use crate::helpers::*;
 use crate::tables::*;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Reader {
     files: Vec<File>,
     namespaces: std::collections::BTreeMap<String, NamespaceData>,
 }
 
+#[derive(Debug, Clone)]
 pub struct NamespaceIterator<'a> {
     reader: &'a Reader,
     iter: std::collections::btree_map::Iter<'a, String, NamespaceData>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TypeIterator<'a> {
     reader: &'a Reader,
     iter: std::slice::Iter<'a, (u32, u32)>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Namespace<'a> {
     reader: &'a Reader,
     name: &'a str,
     types: &'a NamespaceData,
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct NamespaceData {
     index: std::collections::BTreeMap<String, (u32, u32)>,
     interfaces: Vec<(u32, u32)>,

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -7,33 +7,38 @@ use crate::file::*;
 use crate::tables::*;
 use std::convert::*;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenericSig<'a> {
     sig_type: TypeDefOrRef<'a>,
     args: Vec<TypeSig<'a>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModifierSig<'a> {
     sig_type: TypeDefOrRef<'a>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MethodSig<'a> {
     return_type: Option<TypeSig<'a>>,
     params: Vec<(Param<'a>, ParamSig<'a>)>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParamSig<'a> {
     modifiers: Vec<ModifierSig<'a>>,
     by_ref: bool,
     sig_type: TypeSig<'a>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeSig<'a> {
     array: bool,
     modifiers: Vec<ModifierSig<'a>>,
     sig_type: TypeSigType<'a>,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ArgumentSig<'a> {
     Bool(bool),
     Char(char),
@@ -51,6 +56,7 @@ pub enum ArgumentSig<'a> {
     Type(TypeDef<'a>),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeSigType<'a> {
     ElementType(ElementType),
     TypeDefOrRef(TypeDefOrRef<'a>),
@@ -59,7 +65,7 @@ pub enum TypeSigType<'a> {
     GenericMethodIndex(u32),
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ElementType {
     Bool,
     Char,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -7,7 +7,7 @@ use crate::signatures::*;
 
 macro_rules! table {
     ($name:ident) => {
-        #[derive(Copy, Clone)]
+        #[derive(Debug, Copy, Clone, Eq)]
         pub struct $name<'a> {
             pub(crate) row: RowData<'a>,
         }
@@ -36,6 +36,7 @@ table!(TypeDef);
 table!(TypeRef);
 table!(TypeSpec);
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ConstantValue {
     I32(i32),
     U32(u32),


### PR DESCRIPTION
Added `Debug`, `Copy`, `Clone`, `PartialEq`, `Eq` and `Error` derives and implementations where applicable, to allow users to easily integrate the crate into their workflows and projects